### PR TITLE
Add data scripts

### DIFF
--- a/scripts/database/create-tables.sql
+++ b/scripts/database/create-tables.sql
@@ -1,0 +1,94 @@
+DROP TABLE IF EXISTS person CASCADE;
+CREATE TABLE person (
+	person_id SERIAL PRIMARY KEY,
+	first_name VARCHAR NOT NULL,
+	last_name VARCHAR NOT NULL,
+	peer_teacher BOOL,
+	teaching_assistant BOOL,
+	administrator BOOL,
+	professor BOOL
+);
+
+DROP TABLE IF EXISTS person_availability CASCADE;
+CREATE TABLE person_availability (
+	person_id INTEGER REFERENCES person(person_id),
+	weekday WEEKDAY,
+	start_time TIME,
+	end_time TIME,
+	PRIMARY KEY(person_id, weekday, start_time, end_time)
+);
+
+DROP TABLE IF EXISTS office_hours CASCADE;
+CREATE TABLE office_hours (
+	person_id INTEGER REFERENCES person(person_id),
+	weekday WEEKDAY,
+	start_time TIME,
+	end_time TIME,
+	place VARCHAR,
+	PRIMARY KEY(person_id, weekday, start_time, end_time)
+);
+
+DROP TABLE IF EXISTS professor_staff CASCADE;
+CREATE TABLE professor_staff (
+	person_id_professor INTEGER REFERENCES person(person_id),
+	person_id_teaching_assistant INTEGER REFERENCES person(person_id),
+	PRIMARY KEY(person_id_professor, person_id_teaching_assistant)
+);
+
+DROP TABLE IF EXISTS course CASCADE;
+CREATE TABLE course (
+	course_id SERIAL PRIMARY KEY,
+	department VARCHAR(4) NOT NULL,
+	course_number VARCHAR(5) NOT NULL,
+	course_name VARCHAR
+);
+
+DROP TABLE IF EXISTS qualification CASCADE;
+CREATE TABLE qualification (
+	person_id INTEGER REFERENCES person(person_id),
+	course_id INTEGER REFERENCES course(course_id),
+	grade CHAR NOT NULL DEFAULT 'X',
+	PRIMARY KEY(person_id, course_id)
+);
+
+DROP TABLE IF EXISTS course_section CASCADE;
+CREATE TABLE course_section (
+	section_id SERIAL PRIMARY KEY,
+	course_id INTEGER REFERENCES course(course_id) NOT NULL,
+	section_number CHAR(3) NOT NULL
+);
+
+DROP TABLE IF EXISTS section_meeting CASCADE;
+CREATE TABLE section_meeting (
+	section_id INTEGER REFERENCES course_section(section_id),
+	weekday WEEKDAY,
+	start_time TIME,
+	end_time TIME,
+	place VARCHAR,
+	PRIMARY KEY(section_id, weekday, start_time, end_time)
+);
+
+DROP TABLE IF EXISTS section_assignment_preference CASCADE;
+CREATE TABLE section_assignment_preference (
+	person_id INTEGER REFERENCES person(person_id),
+	section_id INTEGER REFERENCES course_section(section_id),
+	preference PREFERENCE NOT NULL DEFAULT 'Indifferent',
+	PRIMARY KEY(person_id, section_id)
+);
+
+DROP TABLE IF EXISTS section_assignment CASCADE;
+CREATE TABLE section_assignment (
+	person_id INTEGER REFERENCES person(person_id),
+	section_id INTEGER REFERENCES course_section(section_id),
+	PRIMARY KEY(person_id, section_id)
+);
+
+DROP TABLE IF EXISTS trade_request CASCADE;
+CREATE TABLE trade_request (
+	person_id_sender INTEGER REFERENCES person(person_id),
+	section_id_sender INTEGER REFERENCES course_section(section_id),
+	person_id_receiver INTEGER REFERENCES person(person_id),
+	section_id_receiver INTEGER REFERENCES course_section(section_id),
+	request_status REQUEST_STATUS NOT NULL DEFAULT 'Pending',
+	PRIMARY KEY(person_id_sender, section_id_sender, person_id_receiver, section_id_receiver)
+);

--- a/scripts/database/schedule-converter.py
+++ b/scripts/database/schedule-converter.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python3
+
+import csv
+import sys, getopt
+from time import time
+
+def convert_to_subfiles(inputfp: str, coursefp: str, sectionfp: str, meetingfp: str, time_zone: str):
+    courses: set[str] = set()
+    sections: set[str] = set()
+    with open(inputfp) as inputf, open(coursefp, 'w') as coursef, open(sectionfp, 'w') as sectionf, open(meetingfp, 'w') as meetingf:
+        coursef.write(f'department,course_number,course_name\n')
+        sectionf.write(f'department,course_number,section_number\n')
+        meetingf.write(f'department,course_number,section_number,weekday,start_time,end_time,place\n')
+        csvreader = csv.DictReader(inputf)
+        _headers = csvreader.fieldnames
+        for line in csvreader:
+            course_section_first_space: int = line['Course/Section'].find(' ')
+            course_section_slash: int = line['Course/Section'].find('/')
+            course_section_second_space: int = line['Course/Section'].find(' ', course_section_first_space + 1)
+            department = line['Course/Section'][:course_section_first_space]
+            course_number = line['Course/Section'][course_section_first_space + 1:course_section_slash]
+            section_number = line['Course/Section'][course_section_slash + 1:course_section_second_space]
+            weekday = line['Days Met']
+            start_time = f"{line['Start Time']} {time_zone}"
+            end_time = f"{line['End Time']} {time_zone}"
+            place = line['Room']
+            if f'{department} {course_number}' not in courses:
+                coursef.write(f'{department},{course_number},\n')
+                courses.add(f'{department} {course_number}')
+            if f'{department} {course_number} {section_number}' not in sections:
+                sectionf.write(f'{department},{course_number},{section_number}')
+                sections.add(f'{department} {course_number} {section_number}')
+            for day in weekday:
+                if day == 'M':
+                    meetingf.write(f'{department},{course_number},{section_number},Monday,{start_time},{end_time},{place}\n')
+                elif day == 'T':
+                    meetingf.write(f'{department},{course_number},{section_number},Tuesday,{start_time},{end_time},{place}\n')
+                elif day == 'W':
+                    meetingf.write(f'{department},{course_number},{section_number},Wednesday,{start_time},{end_time},{place}\n')
+                elif day == 'R':
+                    meetingf.write(f'{department},{course_number},{section_number},Thursday,{start_time},{end_time},{place}\n')
+                elif day == 'F':
+                    meetingf.write(f'{department},{course_number},{section_number},Friday,{start_time},{end_time},{place}\n')
+                elif day == 'S':
+                    meetingf.write(f'{department},{course_number},{section_number},Saturday,{start_time},{end_time},{place}\n')
+                elif day == 'U':
+                    meetingf.write(f'{department},{course_number},{section_number},Sunday,{start_time},{end_time},{place}\n')
+
+def main(argv: list[str]) -> None:
+    inputfile: str = ""
+    coursefile: str = ""
+    sectionfile: str = ""
+    meetingfile: str = ""
+    time_zone: str
+    try:
+        opts, args = getopt.getopt(argv[1:], "hi:c:s:m:t:", ["help", "input=", "course=", "section=", "meeting=", "time-zone="])
+    except getopt.GetoptError:
+        print(f'{argv[0]} -i <inputfile> -c <coursefile> -s <sectionfile> -m <meetingfile>')
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt in ('-h', '--help'):
+            print(f'{argv[0]} -i <inputfile> -c <coursefile> -s <sectionfile> -m <meetingfile>')
+            sys.exit()
+        elif opt in ('-i', '--input'):
+            inputfile = arg
+        elif opt in ('-c', '--course'):
+            coursefile = arg
+        elif opt in ('-s', '--section'):
+            sectionfile = arg
+        elif opt in ('-m', '--meeting'):
+            meetingfile = arg
+        elif opt in ('-t', '--time-zone'):
+            time_zone = arg
+    if inputfile.strip() == "":
+        print(f'{argv[0]} -i <inputfile> -c <coursefile> -s <sectionfile> -m <meetingfile>')
+        print('Error, missing input file.')
+        sys.exit(3)
+    csvindex: int = inputfile.rfind(".csv")
+    if coursefile.strip() == "":
+        coursefile = inputfile[:csvindex] + '-course' + inputfile[csvindex:]
+    if sectionfile.strip() == "":
+        sectionfile = inputfile[:csvindex] + '-section' + inputfile[csvindex:]
+    if meetingfile.strip() == "":
+        meetingfile = inputfile[:csvindex] + '-meeting' + inputfile[csvindex:]
+    convert_to_subfiles(inputfile, coursefile, sectionfile, meetingfile, time_zone)
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/database/schedule-converter.py
+++ b/scripts/database/schedule-converter.py
@@ -7,16 +7,20 @@ from time import time
 def convert_to_subfiles(inputfp: str, coursefp: str, sectionfp: str, meetingfp: str, time_zone: str):
     courses: set[str] = set()
     sections: set[str] = set()
+
     with open(inputfp) as inputf, open(coursefp, 'w') as coursef, open(sectionfp, 'w') as sectionf, open(meetingfp, 'w') as meetingf:
-        coursef.write(f'department,course_number,course_name\n')
-        sectionf.write(f'department,course_number,section_number\n')
-        meetingf.write(f'department,course_number,section_number,weekday,start_time,end_time,place\n')
+        coursef.write('department,course_number,course_name\n')
+        sectionf.write('department,course_number,section_number\n')
+        meetingf.write('department,course_number,section_number,weekday,start_time,end_time,place\n')
+
         csvreader = csv.DictReader(inputf)
         _headers = csvreader.fieldnames
+
         for line in csvreader:
             course_section_first_space: int = line['Course/Section'].find(' ')
             course_section_slash: int = line['Course/Section'].find('/')
             course_section_second_space: int = line['Course/Section'].find(' ', course_section_first_space + 1)
+
             department = line['Course/Section'][:course_section_first_space]
             course_number = line['Course/Section'][course_section_first_space + 1:course_section_slash]
             section_number = line['Course/Section'][course_section_slash + 1:course_section_second_space]
@@ -24,27 +28,27 @@ def convert_to_subfiles(inputfp: str, coursefp: str, sectionfp: str, meetingfp: 
             start_time = f"{line['Start Time']} {time_zone}"
             end_time = f"{line['End Time']} {time_zone}"
             place = line['Room']
+
             if f'{department} {course_number}' not in courses:
                 coursef.write(f'{department},{course_number},\n')
                 courses.add(f'{department} {course_number}')
             if f'{department} {course_number} {section_number}' not in sections:
                 sectionf.write(f'{department},{course_number},{section_number}')
                 sections.add(f'{department} {course_number} {section_number}')
+
+            weekday_map = {
+                'M': 'Monday',
+                'T': 'Tuesday',
+                'W': 'Wednesday',
+                'R': 'Thursday',
+                'F': 'Friday',
+                'S': 'Saturday',
+                'U': 'Sunday'
+            }
+
             for day in weekday:
-                if day == 'M':
-                    meetingf.write(f'{department},{course_number},{section_number},Monday,{start_time},{end_time},{place}\n')
-                elif day == 'T':
-                    meetingf.write(f'{department},{course_number},{section_number},Tuesday,{start_time},{end_time},{place}\n')
-                elif day == 'W':
-                    meetingf.write(f'{department},{course_number},{section_number},Wednesday,{start_time},{end_time},{place}\n')
-                elif day == 'R':
-                    meetingf.write(f'{department},{course_number},{section_number},Thursday,{start_time},{end_time},{place}\n')
-                elif day == 'F':
-                    meetingf.write(f'{department},{course_number},{section_number},Friday,{start_time},{end_time},{place}\n')
-                elif day == 'S':
-                    meetingf.write(f'{department},{course_number},{section_number},Saturday,{start_time},{end_time},{place}\n')
-                elif day == 'U':
-                    meetingf.write(f'{department},{course_number},{section_number},Sunday,{start_time},{end_time},{place}\n')
+                meetingf.write(f'{department},{course_number},{section_number},{weekday_map[day]},{start_time},{end_time},{place}\n')
+
 
 def main(argv: list[str]) -> None:
     inputfile: str = ""
@@ -52,11 +56,13 @@ def main(argv: list[str]) -> None:
     sectionfile: str = ""
     meetingfile: str = ""
     time_zone: str
+
     try:
         opts, args = getopt.getopt(argv[1:], "hi:c:s:m:t:", ["help", "input=", "course=", "section=", "meeting=", "time-zone="])
     except getopt.GetoptError:
         print(f'{argv[0]} -i <inputfile> -c <coursefile> -s <sectionfile> -m <meetingfile>')
         sys.exit(2)
+
     for opt, arg in opts:
         if opt in ('-h', '--help'):
             print(f'{argv[0]} -i <inputfile> -c <coursefile> -s <sectionfile> -m <meetingfile>')
@@ -71,17 +77,22 @@ def main(argv: list[str]) -> None:
             meetingfile = arg
         elif opt in ('-t', '--time-zone'):
             time_zone = arg
+
     if inputfile.strip() == "":
         print(f'{argv[0]} -i <inputfile> -c <coursefile> -s <sectionfile> -m <meetingfile>')
         print('Error, missing input file.')
         sys.exit(3)
+
     csvindex: int = inputfile.rfind(".csv")
     if coursefile.strip() == "":
         coursefile = inputfile[:csvindex] + '-course' + inputfile[csvindex:]
+
     if sectionfile.strip() == "":
         sectionfile = inputfile[:csvindex] + '-section' + inputfile[csvindex:]
+
     if meetingfile.strip() == "":
         meetingfile = inputfile[:csvindex] + '-meeting' + inputfile[csvindex:]
+
     convert_to_subfiles(inputfile, coursefile, sectionfile, meetingfile, time_zone)
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've been working on some scripts for processing database data. I've put them here in the repo, and we can merge them to `main` if we want to have them there.

[`schedule-converter.py`](./schedule-converter.py) - Converts the Spring_2022.csv into a set of multiple CSV files that can be imported into PostgreSQL. This script effectively assumes the format of Spring_2022.csv will never change and that is a **very bad assumption** in the long term. As a result, I want to *deprecate* this script as soon as we can confirm a better way to get access to the data. Also, my Python is rusty so this script is probably hard to read.

[`create-tables.sql`](./create-tables.sql) - This script's name is misleading because it actually destroys all of the existing tables and then recreates them from scratch. Very useful if you're first setting up your database or if things are irrevocably broken.

For now, I'm happy to leave these here, so I'm creating the PR as a draft, but we can make it mergeable if we decide to put this code into `main`.