### PR TITLE
Ben/render enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/jest": "^27.4.1",
         "@types/node": "^16.11.25",
         "@types/react-dom": "^17.0.11",
+        "hsluv": "^0.1.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-google-login": "^5.2.2",
@@ -7528,6 +7529,11 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/hsluv": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.1.0.tgz",
+      "integrity": "sha512-ERcanKLAszD2XN3Vh5r5Szkrv9q0oSTudmP0rkiKAGM/3NMc9FLmMZBB7TSqTaXJfSDBOreYTfjezCOYbRKqlw=="
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -19973,6 +19979,11 @@
           }
         }
       }
+    },
+    "hsluv": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.1.0.tgz",
+      "integrity": "sha512-ERcanKLAszD2XN3Vh5r5Szkrv9q0oSTudmP0rkiKAGM/3NMc9FLmMZBB7TSqTaXJfSDBOreYTfjezCOYbRKqlw=="
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/jest": "^27.4.1",
     "@types/node": "^16.11.25",
     "@types/react-dom": "^17.0.11",
+    "hsluv": "^0.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-google-login": "^5.2.2",
@@ -43,11 +44,11 @@
     ]
   },
   "devDependencies": {
+    "@types/pg": "^8.6.4",
     "@types/react": "^17.0.39",
     "@types/react-test-renderer": "^17.0.1",
-    "react-test-renderer": "^17.0.2",
-    "@types/pg": "^8.6.4",
     "csv": "^6.0.5",
-    "pg": "^8.7.3"
+    "pg": "^8.7.3",
+    "react-test-renderer": "^17.0.2"
   }
 }

--- a/src/Components/EmployeeList/EmployeeList.tsx
+++ b/src/Components/EmployeeList/EmployeeList.tsx
@@ -75,7 +75,7 @@ export const EmployeeList: FC<Props> = ({data}) => {
 
       <div className="scrollable">
         { data.map((e, index) => (
-          < EmployeeRow key={index} element={e} />
+          < EmployeeRow key={index} linkID={index} element={e} />
         ))}
       </div>
 

--- a/src/Components/EmployeeList/EmployeeRow.tsx
+++ b/src/Components/EmployeeList/EmployeeRow.tsx
@@ -17,7 +17,7 @@ export const EmployeeRow: FC<Props> = ({element, linkID}) => {
          {element}
         </div>
         <div className="element right">
-          < Dot linkID={linkID} styles={{margin: '0', width: '0.7em'}}/>
+          < Dot linkID={linkID} />
         </div>
       </div>
       <div className="hr-container">

--- a/src/Components/EmployeeList/EmployeeRow.tsx
+++ b/src/Components/EmployeeList/EmployeeRow.tsx
@@ -2,10 +2,11 @@ import React, { FC } from 'react'
 import { Dot } from '../Misc/Dot'
 
 interface Props {
-	element: string // The body of the list element
+	element: string, // The body of the list element
+  linkID: number
 }
 
-export const EmployeeRow: FC<Props> = ({element}) => {
+export const EmployeeRow: FC<Props> = ({element, linkID}) => {
   return (
     <>
       <div className="hstack">
@@ -16,7 +17,7 @@ export const EmployeeRow: FC<Props> = ({element}) => {
          {element}
         </div>
         <div className="element right">
-          < Dot linkID={Math.floor(Math.random()*20)} styles={{margin: '0', width: '0.7em'}}/> {/* TODO: Random Keys to be replaced */}
+          < Dot linkID={linkID} styles={{margin: '0', width: '0.7em'}}/>
         </div>
       </div>
       <div className="hr-container">

--- a/src/Components/Misc/Dot.tsx
+++ b/src/Components/Misc/Dot.tsx
@@ -3,7 +3,6 @@ import colorFromId from './color'
 
 interface Props {
   linkID: number // An id that ties this dot corresponding dots elsewhere on the page
-  styles?: any
 }
 
 // Adds or removes a class from dots with or without a certain link ID
@@ -19,7 +18,7 @@ const modifyDots = (id: number, newClass: string, inverted: boolean = false, rem
   else linkedDots.forEach(e => e.classList.add(newClass));
 
   if (remove) {
-    setTimeout(() => linkedHats.forEach(e => e.classList.remove(newClass)), 200);
+    setTimeout(() => linkedHats.forEach(e => e.classList.remove(newClass)), 200); // Makes syre 
   } else {
     linkedHats.forEach(e => e.classList.add(newClass));
   }
@@ -31,6 +30,7 @@ interface modifyBlocksOptions {
   remove?: boolean,
   exclude?: boolean
 }
+
 const modifyBlocks = (id: number, newClass: string, options: modifyBlocksOptions) => {
   const { inverted, remove, exclude } = options;
   const candidates = `div.hat${((inverted === true)? ':not(' : '')}[link-id="${id}"]${((inverted === true)? ')' : '')}`;
@@ -40,19 +40,12 @@ const modifyBlocks = (id: number, newClass: string, options: modifyBlocksOptions
   let linked = Array.from(document.querySelectorAll(candidates))
   if (exclude === true) linked = linked.filter(e => excluded.indexOf(e.parentElement?.parentElement) === -1);
 
-  console.log({
-    filtered: linked,
-    ex: excluded,
-    candidates: candidates,
-    exclusions: exclusions
-  })
-
   if (remove) linked.forEach(e => e.parentElement?.parentElement?.classList.remove(newClass));
   else linked.forEach(e => e.parentElement?.parentElement?.classList.add(newClass));
 }
 
 
-export const Dot: FC<Props> = ({linkID, styles}) => {
+export const Dot: FC<Props> = ({linkID}) => {
   const [selected, setSelected] = useState(false);
   const ref: any = useRef(null);
   
@@ -68,7 +61,7 @@ export const Dot: FC<Props> = ({linkID, styles}) => {
     return () => {
       document.removeEventListener('click', handleClickOutside, true);
     };
-  }, [ selected, ref ]);
+  });
 
   const emphasizeLinked = () => {
     modifyDots(linkID, 'emphasized'); // Give all dots with the same link ID the selected property
@@ -81,15 +74,16 @@ export const Dot: FC<Props> = ({linkID, styles}) => {
   }
 
   const toggleSelect = (forceState?: boolean) => {
-    if (forceState !== undefined) setSelected(forceState);
-
-    if (selected) { // Restores the page to no longer highlight certain dots
+    if (selected) {
+      // Restores the page to no longer highlight certain dots
       modifyDots(linkID, 'selected', false, true);
       modifyBlocks(linkID, 'selected', {inverted: false, remove: true});
 
       modifyDots(linkID, 'deselected', true, true);
       modifyBlocks(linkID, 'deselected', {inverted: true, remove: true, exclude: true});
-    } else { // Shrinks other dots and blocks to allow focus on a particular set of dots
+
+    } else {
+      // Shrinks other dots and blocks to allow focus on a particular set of dots
       modifyDots(linkID, 'selected');
       modifyBlocks(linkID, 'selected', {});
 
@@ -107,7 +101,7 @@ export const Dot: FC<Props> = ({linkID, styles}) => {
       ref={ref}
       className="dot" 
       link-id={linkID} 
-      style={{backgroundColor: `rgb(${r}, ${g}, ${b})`, ...styles}} 
+      style={{backgroundColor: `rgb(${r}, ${g}, ${b})`}} 
       onMouseOver={emphasizeLinked} 
       onMouseOut={deemphasizeLinked}
       onClick={() => toggleSelect()}

--- a/src/Components/Misc/Dot.tsx
+++ b/src/Components/Misc/Dot.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 // Adds or removes a class from dots with or without a certain link ID
 const modifyDots = (id: number, newClass: string, inverted: boolean = false, remove: boolean = false) => {
-  const selector = `div.dot${(inverted? ':not(' : '')}[link-id="${id}"]${(inverted? ')' : '')}`;
+  const selector = `div.hat${(inverted? ':not(' : '')}[link-id="${id}"]${(inverted? ')' : '')}, div.dot${(inverted? ':not(' : '')}[link-id="${id}"]${(inverted? ')' : '')}`;
   let linked = Array.from(document.querySelectorAll(selector));
   if (remove) linked.forEach(e => e.classList.remove(newClass));
   else linked.forEach(e => e.classList.add(newClass));
@@ -17,7 +17,7 @@ const modifyDots = (id: number, newClass: string, inverted: boolean = false, rem
 
 // Adds or removes a class from blocks containing dots with or without a certain link ID
 const modifyBlocks = (id: number, newClass: string, inverted: boolean = false, remove: boolean = false) => {
-  const selector = `div.dot${(inverted? ':not(' : '')}[link-id="${id}"]${(inverted? ')' : '')}`;
+  const selector = `div.hat${(inverted? ':not(' : '')}[link-id="${id}"]${(inverted? ')' : '')}`;
   let linked = Array.from(document.querySelectorAll(selector));
   if (remove) linked.forEach(e => e.parentElement?.parentElement?.classList.remove(newClass));
   else linked.forEach(e => e.parentElement?.parentElement?.classList.add(newClass));
@@ -57,10 +57,14 @@ export const Dot: FC<Props> = ({linkID, styles}) => {
 
     if (selected) { // Restores the page to no longer highlight certain dots
       modifyDots(linkID, 'selected', false, true);
+      modifyBlocks(linkID, 'selected', false, true);
+
       modifyDots(linkID, 'deselected', true, true);
       modifyBlocks(linkID, 'deselected', true, true);
     } else { // Shrinks other dots and blocks to allow focus on a particular set of dots
       modifyDots(linkID, 'selected');
+      modifyBlocks(linkID, 'selected');
+
       modifyDots(linkID, 'deselected', true);
       modifyBlocks(linkID, 'deselected', true);
     }

--- a/src/Components/Misc/Dot.tsx
+++ b/src/Components/Misc/Dot.tsx
@@ -8,10 +8,21 @@ interface Props {
 
 // Adds or removes a class from dots with or without a certain link ID
 const modifyDots = (id: number, newClass: string, inverted: boolean = false, remove: boolean = false) => {
-  const selector = `div.hat${(inverted? ':not(' : '')}[link-id="${id}"]${(inverted? ')' : '')}, div.dot${(inverted? ':not(' : '')}[link-id="${id}"]${(inverted? ')' : '')}`;
-  let linked = Array.from(document.querySelectorAll(selector));
-  if (remove) linked.forEach(e => e.classList.remove(newClass));
-  else linked.forEach(e => e.classList.add(newClass));
+  const hats = `div.hat${(inverted? ':not(' : '')}[link-id="${id}"]${(inverted? ')' : '')}`;
+  let linkedHats = Array.from(document.querySelectorAll(hats));
+  if (remove) linkedHats.forEach(e => e.parentElement?.classList.remove(newClass));
+  else linkedHats.forEach(e => e.parentElement?.classList.add(newClass));
+  
+  const dots = `div.dot${(inverted? ':not(' : '')}[link-id="${id}"]${(inverted? ')' : '')}`;
+  let linkedDots = Array.from(document.querySelectorAll(dots));
+  if (remove) linkedDots.forEach(e => e.classList.remove(newClass));
+  else linkedDots.forEach(e => e.classList.add(newClass));
+
+  if (remove) {
+    setTimeout(() => linkedHats.forEach(e => e.classList.remove(newClass)), 200);
+  } else {
+    linkedHats.forEach(e => e.classList.add(newClass));
+  }
 }
 
 // Adds or removes a class from blocks containing dots with or without a certain link ID
@@ -24,10 +35,10 @@ const modifyBlocks = (id: number, newClass: string, options: modifyBlocksOptions
   const { inverted, remove, exclude } = options;
   const candidates = `div.hat${((inverted === true)? ':not(' : '')}[link-id="${id}"]${((inverted === true)? ')' : '')}`;
   const exclusions = `div.hat${((inverted !== true)? ':not(' : '')}[link-id="${id}"]${((inverted !== true)? ')' : '')}`;
-  const excluded = Array.from(document.querySelectorAll(exclusions)).map(e => e.parentElement).filter((e, i, s) => s.indexOf(e) === i);
+  const excluded = Array.from(document.querySelectorAll(exclusions)).map(e => e.parentElement?.parentElement).filter((e, i, s) => s.indexOf(e) === i);
 
   let linked = Array.from(document.querySelectorAll(candidates))
-  if (exclude === true) linked = linked.filter(e => excluded.indexOf(e.parentElement) === -1);
+  if (exclude === true) linked = linked.filter(e => excluded.indexOf(e.parentElement?.parentElement) === -1);
 
   console.log({
     filtered: linked,
@@ -36,8 +47,8 @@ const modifyBlocks = (id: number, newClass: string, options: modifyBlocksOptions
     exclusions: exclusions
   })
 
-  if (remove) linked.forEach(e => e.parentElement?.classList.remove(newClass));
-  else linked.forEach(e => e.parentElement?.classList.add(newClass));
+  if (remove) linked.forEach(e => e.parentElement?.parentElement?.classList.remove(newClass));
+  else linked.forEach(e => e.parentElement?.parentElement?.classList.add(newClass));
 }
 
 

--- a/src/Components/Misc/Dot.tsx
+++ b/src/Components/Misc/Dot.tsx
@@ -1,6 +1,5 @@
 import React, { FC, useEffect, useRef, useState } from 'react'
-import Palette from '../../assets/colors.json'
-import uuid from '../../uuid'
+import colorFromId from './color'
 
 interface Props {
   linkID: number // An id that ties this dot corresponding dots elsewhere on the page
@@ -90,12 +89,14 @@ export const Dot: FC<Props> = ({linkID, styles}) => {
     if (forceState === undefined) setSelected(!selected);
   }
 
+  const {r, g, b} = colorFromId(linkID);
+
   return (
     <div 
       ref={ref}
       className="dot" 
       link-id={linkID} 
-      style={{backgroundColor: Palette.colors[linkID % Palette.colors.length], ...styles}} 
+      style={{backgroundColor: `rgb(${r}, ${g}, ${b})`, ...styles}} 
       onMouseOver={emphasizeLinked} 
       onMouseOut={deemphasizeLinked}
       onClick={() => toggleSelect()}

--- a/src/Components/Misc/Dot.tsx
+++ b/src/Components/Misc/Dot.tsx
@@ -19,8 +19,8 @@ const modifyDots = (id: number, newClass: string, inverted: boolean = false, rem
 const modifyBlocks = (id: number, newClass: string, inverted: boolean = false, remove: boolean = false) => {
   const selector = `div.hat${(inverted? ':not(' : '')}[link-id="${id}"]${(inverted? ')' : '')}`;
   let linked = Array.from(document.querySelectorAll(selector));
-  if (remove) linked.forEach(e => e.parentElement?.parentElement?.classList.remove(newClass));
-  else linked.forEach(e => e.parentElement?.parentElement?.classList.add(newClass));
+  if (remove) linked.forEach(e => e.parentElement?.classList.remove(newClass));
+  else linked.forEach(e => e.parentElement?.classList.add(newClass));
 }
 
 

--- a/src/Components/Misc/GoogleButton.tsx
+++ b/src/Components/Misc/GoogleButton.tsx
@@ -73,15 +73,3 @@ export const GoogleButton = () => {
     </>
   )
 }
-
-// backgroundColor: 'white',
-// display: inline-flex
-// align-items: center
-// color: rgba(0, 0, 0, 0.54)
-// box-shadow: rgba(0, 0, 0, 0.24) 0px 2px 2px 0px, rgba(0, 0, 0, 0.24) 0px 0px 1px 0px
-// padding: 0px
-// border-radius: 2px
-// border: 1px solid transparent
-// font-size: 14px
-// font-weight: 500
-// font-family: Roboto, sans-serif; opacity: 0.6;

--- a/src/Components/Misc/Hat.tsx
+++ b/src/Components/Misc/Hat.tsx
@@ -2,13 +2,14 @@ import React, { FC } from 'react'
 import colorFromId from './color'
 
 interface Props {
-  linkID: number // An id that ties this dot corresponding dots elsewhere on the page
+  linkID: number, // An id that ties this dot corresponding dots elsewhere on the page
+  name?: string, // A name to display in the hat
   styles?: any
 }
 
 
 
-export const Hat: FC<Props> = ({linkID, styles}) => {
+export const Hat: FC<Props> = ({linkID, name, styles}) => {
   const {r, g, b, l} = colorFromId(linkID);
   const colors = {
     backgroundColor: `rgb(${r}, ${g}, ${b})`,
@@ -21,6 +22,6 @@ export const Hat: FC<Props> = ({linkID, styles}) => {
       link-id={linkID} 
       style={{...colors, ...styles}} 
       data-testid="hat"
-    >Text</div>
+    >{name}</div>
   )
 }

--- a/src/Components/Misc/Hat.tsx
+++ b/src/Components/Misc/Hat.tsx
@@ -1,17 +1,21 @@
 import React, { FC } from 'react'
-import Palette from '../../assets/colors.json'
+import colorFromId from './color'
 
 interface Props {
   linkID: number // An id that ties this dot corresponding dots elsewhere on the page
   styles?: any
 }
 
+
+
 export const Hat: FC<Props> = ({linkID, styles}) => {
+  const {r, g, b, l} = colorFromId(linkID);
+
   return (
     <div 
       className="hat" 
       link-id={linkID} 
-      style={{backgroundColor: Palette.colors[linkID % Palette.colors.length], ...styles}} 
+      style={{backgroundColor: `rgb(${r}, ${g}, ${b})`, color: (l <= 50)? 'white' : 'black', ...styles}} 
       data-testid="hat"
     >
       Text

--- a/src/Components/Misc/Hat.tsx
+++ b/src/Components/Misc/Hat.tsx
@@ -1,6 +1,5 @@
-import React, { FC, useEffect, useRef, useState } from 'react'
+import React, { FC } from 'react'
 import Palette from '../../assets/colors.json'
-import uuid from '../../uuid'
 
 interface Props {
   linkID: number // An id that ties this dot corresponding dots elsewhere on the page

--- a/src/Components/Misc/Hat.tsx
+++ b/src/Components/Misc/Hat.tsx
@@ -1,12 +1,6 @@
 import React, { FC } from 'react'
 import colorFromId from './color'
 
-interface Props {
-  linkID: number, // An id that ties this dot corresponding dots elsewhere on the page
-  name?: string, // A name to display in the hat
-  styles?: any
-}
-
 function getData(): Array<string> {
 	return [
 		"Geralt of Rivia",
@@ -65,7 +59,12 @@ function getData(): Array<string> {
 	];
 }
 
-export const Hat: FC<Props> = ({linkID, name, styles}) => {
+interface Props {
+  linkID: number, // An id that ties this dot corresponding dots elsewhere on the page
+  name?: string, // A name to display in the hat
+}
+
+export const Hat: FC<Props> = ({linkID, name}) => {
   const {r, g, b, l} = colorFromId(linkID);
   const colors = {
     backgroundColor: `rgb(${r}, ${g}, ${b})`,
@@ -77,7 +76,7 @@ export const Hat: FC<Props> = ({linkID, name, styles}) => {
       className="hat" 
       link-id={linkID} 
       title={getData()[linkID]}
-      style={{...colors, ...styles}} 
+      style={colors} 
       data-testid="hat"
     >{getData()[linkID]}</div>
   )

--- a/src/Components/Misc/Hat.tsx
+++ b/src/Components/Misc/Hat.tsx
@@ -1,0 +1,19 @@
+import React, { FC, useEffect, useRef, useState } from 'react'
+import Palette from '../../assets/colors.json'
+import uuid from '../../uuid'
+
+interface Props {
+  linkID: number // An id that ties this dot corresponding dots elsewhere on the page
+  styles?: any
+}
+
+export const Hat: FC<Props> = ({linkID, styles}) => {
+  return (
+    <div 
+      className="hat" 
+      link-id={linkID} 
+      style={{backgroundColor: Palette.colors[linkID % Palette.colors.length], ...styles}} 
+      data-testid="hat"
+    />
+  )
+}

--- a/src/Components/Misc/Hat.tsx
+++ b/src/Components/Misc/Hat.tsx
@@ -10,15 +10,17 @@ interface Props {
 
 export const Hat: FC<Props> = ({linkID, styles}) => {
   const {r, g, b, l} = colorFromId(linkID);
+  const colors = {
+    backgroundColor: `rgb(${r}, ${g}, ${b})`,
+    color: (l <= 50)? 'white' : 'black'
+  }
 
   return (
     <div 
       className="hat" 
       link-id={linkID} 
-      style={{backgroundColor: `rgb(${r}, ${g}, ${b})`, color: (l <= 50)? 'white' : 'black', ...styles}} 
+      style={{...colors, ...styles}} 
       data-testid="hat"
-    >
-      Text
-    </div>
+    >Text</div>
   )
 }

--- a/src/Components/Misc/Hat.tsx
+++ b/src/Components/Misc/Hat.tsx
@@ -7,7 +7,63 @@ interface Props {
   styles?: any
 }
 
-
+function getData(): Array<string> {
+	return [
+		"Geralt of Rivia",
+    "Gary Chess", 
+    "Sandy Banks", 
+    "King Gerold III",
+    "Sharpness IV", 
+    "Zelda DeLegendof",
+    "Star Fox", 
+		"Luigi Smansion", 
+    "John Doom", 
+    "Spongebob Squarepants",
+    "Crash Bandishoot",
+    "Suzzie Sunshine",
+    "Mr. Generic",
+    "Honda Accord",
+    "K.K. Slider",
+    "Gee Wilikers",
+    "Mario Galaxy",
+    "Ms. Generic",
+    "Bubble Bass",
+    "Sandy Cheeks",
+    "Patrick",
+    "Samus Errands",
+    "Timmy Twix",
+    "Marvin M&M",
+    "Bikeal Roads",
+    "Spicy Peppers",
+    "Quintin QWERTY",
+    "Asmorald ASDF",
+    "Timmothy Tingle",
+    "Kimmothy Kartz",
+    "Zimmothy Zions",
+    "Phoenix Wright",
+    "Mia Fey",
+    "Miles Edgeworth",
+    "Maya Fey",
+    "Pearl Fey",
+    "Dick Gumshoe",
+    "Franziska von Karma",
+    "Ema Skye",
+    "The Judge",
+    "Apollo Justice",
+    "Trucy Wright",
+    "Athena Cykes",
+    "Ryunosuke Naruhodo",
+    "Susato Mikotoba",
+    "Herlock Sholmes",
+    "Iris Wilson",
+    "Barok van Zieks",
+    "Tetsutetsu Tetsutetsu",
+    "Bobaboba Bobaboba",
+    "Spike the Cowboy",
+    "Guard the Reserve",
+    "Hero Sandwich"
+	];
+}
 
 export const Hat: FC<Props> = ({linkID, name, styles}) => {
   const {r, g, b, l} = colorFromId(linkID);
@@ -20,8 +76,9 @@ export const Hat: FC<Props> = ({linkID, name, styles}) => {
     <div 
       className="hat" 
       link-id={linkID} 
+      title={getData()[linkID]}
       style={{...colors, ...styles}} 
       data-testid="hat"
-    >{name}</div>
+    >{getData()[linkID]}</div>
   )
 }

--- a/src/Components/Misc/Hat.tsx
+++ b/src/Components/Misc/Hat.tsx
@@ -13,6 +13,8 @@ export const Hat: FC<Props> = ({linkID, styles}) => {
       link-id={linkID} 
       style={{backgroundColor: Palette.colors[linkID % Palette.colors.length], ...styles}} 
       data-testid="hat"
-    />
+    >
+      Text
+    </div>
   )
 }

--- a/src/Components/Misc/color.ts
+++ b/src/Components/Misc/color.ts
@@ -1,0 +1,17 @@
+import hsluv from 'hsluv';
+const colorFromId = (linkID: number) => {
+	const ret = hsluv.hsluvToRgb([
+		linkID*35 % 361,
+		100 - Math.floor(linkID*200 / 361)*31 % 80,
+		60 + 10*(linkID*4 % 7 - 3)
+	])
+
+	return {
+		r: ret[0] * 255,
+		g: ret[1] * 255,
+		b: ret[2] * 255,
+		l: 60 + 10*(linkID*4 % 7 - 3)
+	}
+}
+
+export default colorFromId;

--- a/src/Components/Misc/color.ts
+++ b/src/Components/Misc/color.ts
@@ -2,7 +2,7 @@ import hsluv from 'hsluv';
 const colorFromId = (linkID: number) => {
 	const ret = hsluv.hsluvToRgb([
 		linkID*35 % 361,
-		100 - Math.floor(linkID*200 / 361)*31 % 80,
+		100 - Math.floor(linkID*21 / 361)*31 % 80,
 		60 + 10*(linkID*4 % 7 - 3)
 	])
 

--- a/src/Components/Scheduling/BlockFormer.ts
+++ b/src/Components/Scheduling/BlockFormer.ts
@@ -89,6 +89,16 @@ class BlockFormer {
 
     static samples = {
         Empty_schedule: [],
+        Test_schedule: [
+            {course: 121, section: 101, start: BlockFormer.starts.MW_A, end: BlockFormer.setTimes.MW_A_extralong},
+            {course: 121, section: 106, start: BlockFormer.starts.MW_A, end: BlockFormer.setTimes.MW_A_extralong},
+            {course: 121, section: 106, start: BlockFormer.starts.MW_A, end: BlockFormer.setTimes.MW_A_extralong},
+            
+            {course: 221, section: 102, start: BlockFormer.starts.MW_A, end: BlockFormer.setTimes.MW_A_short},
+            {course: 313, section: 103, start: BlockFormer.starts.MW_A, end: BlockFormer.setTimes.MW_A_short},
+
+            {course: 315, section: 104, start: BlockFormer.starts.MW_B, end: BlockFormer.setTimes.MW_B_short},
+        ],
         M_schedule: [
             // MONDAYS //
             {course: 121, section: 101, start: BlockFormer.starts.MW_A, end: BlockFormer.setTimes.MW_A_short},

--- a/src/Components/Scheduling/SchedulingBlock.tsx
+++ b/src/Components/Scheduling/SchedulingBlock.tsx
@@ -19,10 +19,11 @@ interface CourseInstance { // Results of a join between course, course_section, 
 
 interface Props {
   course_instance: CourseInstance,
-  visible: boolean
+  visible: boolean,
+  linkIDs: number[]
 }
 
-export const SchedulingBlock: FC<Props> = ({course_instance, visible}) => {
+export const SchedulingBlock: FC<Props> = ({course_instance, visible, linkIDs}) => {
   const isVisible = {
     width: visible? undefined : 0,
     flex: visible? undefined : '0 0 auto',
@@ -39,9 +40,7 @@ export const SchedulingBlock: FC<Props> = ({course_instance, visible}) => {
       title={`${course_instance.course}-${course_instance.section}`} 
       style={{backgroundColor: colors.get(course_instance.course), ...isVisible}}
     >
-      {/* <div className="block-indicator slim" style={isContentVisible}> */}
-        < Hat linkID={Math.floor(Math.random()*20)}/> {/* TODO: Random Keys to be replaced }*/}
-      {/* </div> */}
+      {linkIDs.map(id => (< Hat linkID={id}/>))}
       <div className="fill"/>
       <div className="block-text" style={isContentVisible}>
         {course_instance.course} {course_instance.section}

--- a/src/Components/Scheduling/SchedulingBlock.tsx
+++ b/src/Components/Scheduling/SchedulingBlock.tsx
@@ -40,7 +40,9 @@ export const SchedulingBlock: FC<Props> = ({course_instance, visible, linkIDs}) 
       title={`${course_instance.course}-${course_instance.section}`} 
       style={{backgroundColor: colors.get(course_instance.course), ...isVisible}}
     >
-      {linkIDs.map(id => (< Hat linkID={id}/>))}
+      <div className="hat-container">
+        {linkIDs.map(id => (< Hat linkID={id} />))}
+      </div>
       <div className="fill"/>
       <div className="block-text" style={isContentVisible}>
         {course_instance.course} {course_instance.section}

--- a/src/Components/Scheduling/SchedulingBlock.tsx
+++ b/src/Components/Scheduling/SchedulingBlock.tsx
@@ -39,12 +39,14 @@ export const SchedulingBlock: FC<Props> = ({course_instance, visible}) => {
       title={`${course_instance.course}-${course_instance.section}`} 
       style={{backgroundColor: colors.get(course_instance.course), ...isVisible}}
     >
-      <div className="block-indicator slim" style={isContentVisible}>
+      <div className="block-indicator" style={isContentVisible}>
+        < Dot linkID={Math.floor(Math.random()*20)}/> {/* TODO: Random Keys to be replaced }*/}
+        < Dot linkID={Math.floor(Math.random()*20)}/> {/* TODO: Random Keys to be replaced }*/}
         < Dot linkID={Math.floor(Math.random()*20)}/> {/* TODO: Random Keys to be replaced }*/}
       </div>
-      <div className="block-text" style={isContentVisible}>
+      {/* <div className="block-text" style={isContentVisible}>
         {course_instance.course}-{course_instance.section}
-      </div>
+      </div> */}
     </div>
   )
 }

--- a/src/Components/Scheduling/SchedulingBlock.tsx
+++ b/src/Components/Scheduling/SchedulingBlock.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
 import { Dot } from '../Misc/Dot'
+import { Hat } from '../Misc/Hat';
 
 const colors = new Map()
 colors.set(121, '#0086B6');
@@ -40,7 +41,7 @@ export const SchedulingBlock: FC<Props> = ({course_instance, visible}) => {
       style={{backgroundColor: colors.get(course_instance.course), ...isVisible}}
     >
       <div className="block-indicator slim" style={isContentVisible}>
-        < Dot linkID={Math.floor(Math.random()*20)}/> {/* TODO: Random Keys to be replaced }*/}
+        < Hat linkID={Math.floor(Math.random()*20)}/> {/* TODO: Random Keys to be replaced }*/}
       </div>
       <div className="block-text" style={isContentVisible}>
         {course_instance.course}-{course_instance.section}

--- a/src/Components/Scheduling/SchedulingBlock.tsx
+++ b/src/Components/Scheduling/SchedulingBlock.tsx
@@ -40,11 +40,12 @@ export const SchedulingBlock: FC<Props> = ({course_instance, visible}) => {
       title={`${course_instance.course}-${course_instance.section}`} 
       style={{backgroundColor: colors.get(course_instance.course), ...isVisible}}
     >
-      <div className="block-indicator slim" style={isContentVisible}>
+      {/* <div className="block-indicator slim" style={isContentVisible}> */}
         < Hat linkID={Math.floor(Math.random()*20)}/> {/* TODO: Random Keys to be replaced }*/}
-      </div>
+      {/* </div> */}
+      <div className="fill"/>
       <div className="block-text" style={isContentVisible}>
-        {course_instance.course}-{course_instance.section}
+        {course_instance.course} {course_instance.section}
       </div>
     </div>
   )

--- a/src/Components/Scheduling/SchedulingColumn.tsx
+++ b/src/Components/Scheduling/SchedulingColumn.tsx
@@ -90,6 +90,9 @@ const generateBlocks = (data: CourseInstance[], filter: any) => {
   return placeBlocks(base, filter);
 
 }
+
+const r = () => Math.floor(Math.random() * 40);
+const randIDs = () => [r(), r(), r(), r()].filter((e, i, s) => s.indexOf(e) === i);
   
 const placeBlocks = (blocks: CourseInstance[], filter: any) => {
   const unravel = (outer: CourseInstance | CourseInstance[][], parent: CourseInstance) => {
@@ -105,7 +108,7 @@ const placeBlocks = (blocks: CourseInstance[], filter: any) => {
             }}>
               { row.map(c => (
                 // Needs a key
-                < SchedulingBlock course_instance={c} visible={filter[c.course]} />
+                < SchedulingBlock course_instance={c} visible={filter[c.course]} linkIDs={randIDs()} />
               )) }
             </div>
           ))}
@@ -114,7 +117,7 @@ const placeBlocks = (blocks: CourseInstance[], filter: any) => {
     } else {
       return (
         // Needs a key
-        < SchedulingBlock course_instance={outer} visible={filter[outer.course]} />
+        < SchedulingBlock course_instance={outer} visible={filter[outer.course]} linkIDs={randIDs()} />
       )
     }
   }

--- a/src/Components/Scheduling/SchedulingColumn.tsx
+++ b/src/Components/Scheduling/SchedulingColumn.tsx
@@ -96,17 +96,18 @@ const placeBlocks = (blocks: CourseInstance[], filter: any) => {
   const r = () => Math.floor(Math.random() * 40);
   const randIDs = () => [r(), r(), r(), r()].filter((e, i, s) => s.indexOf(e) === i);
 
-  const unravel = (outer: CourseInstance | CourseInstance[][], parent: CourseInstance) => {
+  const unravel = (outer: CourseInstance | CourseInstance[][], parent: CourseInstance, spacerSz: string) => {
     if (Array.isArray(outer)) {
       return (
         // Needs a key
-        <div className="vstack">
+        <div className="vstack absolute">
           { outer.map(row => (
             // Needs a key
             <div className="hstack block-container" style={{
               height: `${time_to_height(row[0].start, row[0].end, d_len(parent))}%`,
               top: `${start_time_to_top(row[0].start, parent.start, d_len(parent))}%`
             }}>
+              <div className="block spacer" style={{flex: `0 0 ${spacerSz}`}}/>
               { row.map(c => (
                 // Needs a key
                 < SchedulingBlock course_instance={c} visible={filter[c.course]} linkIDs={randIDs()} />
@@ -131,6 +132,39 @@ const placeBlocks = (blocks: CourseInstance[], filter: any) => {
       else return d_len(p) > d_len(e) ? p : e;
     }))
   })
+  
+  console.log(blocks);
+
+  let spacers: any = [];
+  let spacerLens: any = [];
+  blocks.forEach((set: any) => {
+
+    // Calculate how many spacers to add to the end of the top level block list
+    let count = 0;
+    set.forEach((subset: any) => {
+      let maxCount = 0;
+      if (Array.isArray(subset)) {
+        subset.forEach((block: any) => {
+          if (Array.isArray(block)) {
+            maxCount = Math.max(maxCount, block.length);
+          } else {
+            maxCount = Math.max(maxCount, 1);
+          }
+        })
+      } else {
+        maxCount = 1;
+      }
+      count = Math.max(maxCount, count);
+    });
+    
+    // Add the spacers to the block list
+    spacers.push([]);
+    for (let j = 0; j < count; j++) {
+      spacers[spacers.length - 1].push(<div className="block spacer"/>)
+    }
+    spacerLens.push(100 * (set.length - 1) / (spacers[spacers.length - 1].length + (set.length - 1)));
+  })
+
 
   return (
     <>
@@ -142,8 +176,9 @@ const placeBlocks = (blocks: CourseInstance[], filter: any) => {
           top: `${start_time_to_top(set[0].start)}%`
         }}>
           { set.map((outer: any) => (
-            unravel(outer, maxes[idx])
+            unravel(outer, maxes[idx], `${spacerLens[idx]}%`)
           ))}
+          { spacers[idx] }
         </div>
       ))}
     </>

--- a/src/Components/Scheduling/SchedulingColumn.tsx
+++ b/src/Components/Scheduling/SchedulingColumn.tsx
@@ -133,8 +133,6 @@ const placeBlocks = (blocks: CourseInstance[], filter: any) => {
     }))
   })
   
-  console.log(blocks);
-
   let spacers: any = [];
   let spacerLens: any = [];
   blocks.forEach((set: any) => {
@@ -151,8 +149,6 @@ const placeBlocks = (blocks: CourseInstance[], filter: any) => {
             maxCount = Math.max(maxCount, 1);
           }
         })
-      } else {
-        maxCount = 1;
       }
       count = Math.max(maxCount, count);
     });
@@ -163,8 +159,12 @@ const placeBlocks = (blocks: CourseInstance[], filter: any) => {
       spacers[spacers.length - 1].push(<div className="block spacer"/>)
     }
     spacerLens.push(100 * (set.length - 1) / (spacers[spacers.length - 1].length + (set.length - 1)));
+    console.log({
+      set: set.length,
+      sp: spacers[spacers.length - 1].length,
+      calc: 100 * (set.length - 1) / (spacers[spacers.length - 1].length + (set.length - 1))
+    })
   })
-
 
   return (
     <>

--- a/src/Components/Scheduling/SchedulingColumn.tsx
+++ b/src/Components/Scheduling/SchedulingColumn.tsx
@@ -97,7 +97,7 @@ const placeBlocks = (blocks: CourseInstance[], filter: any) => {
   const randIDs = () => [r(), r(), r(), r()].filter((e, i, s) => s.indexOf(e) === i);
 
   const unravel = (outer: CourseInstance | CourseInstance[][], parent: CourseInstance, spacerSz: string) => {
-    if (Array.isArray(outer)) {
+    if (Array.isArray(outer)) { // Creates a subview for the smaller elements
       return (
         // Needs a key
         <div className="vstack absolute">
@@ -124,6 +124,7 @@ const placeBlocks = (blocks: CourseInstance[], filter: any) => {
     }
   }
 
+  // Find the largest block for each set of blocks
   let maxes: any = [];
   blocks.forEach((set: any) => {
     maxes.push(set.reduce((p: any, e: any) => {
@@ -158,12 +159,9 @@ const placeBlocks = (blocks: CourseInstance[], filter: any) => {
     for (let j = 0; j < count; j++) {
       spacers[spacers.length - 1].push(<div className="block spacer"/>)
     }
+
+    // Pre-calculate how large the spacer should be in subviews
     spacerLens.push(100 * (set.length - 1) / (spacers[spacers.length - 1].length + (set.length - 1)));
-    console.log({
-      set: set.length,
-      sp: spacers[spacers.length - 1].length,
-      calc: 100 * (set.length - 1) / (spacers[spacers.length - 1].length + (set.length - 1))
-    })
   })
 
   return (

--- a/src/Components/Scheduling/SchedulingColumn.tsx
+++ b/src/Components/Scheduling/SchedulingColumn.tsx
@@ -6,7 +6,6 @@ let numHours = 11;
 
 interface Props {
   blocks: any, // The blocks to be displayed for this day of the week
-  end? : boolean, // Basic styling prop, the column on the end doesn't get a border on the right
   filter: Object,
   day: string, // The day of the week
   hours?: number, // The number of hours in a day
@@ -151,15 +150,10 @@ const placeBlocks = (blocks: CourseInstance[], filter: any) => {
   )
 }
 
-export const SchedulingColumn: FC<Props> = ({blocks, end, filter, day, hours}) => {
+export const SchedulingColumn: FC<Props> = ({blocks, filter, day, hours}) => {
   const [detailed, setDetailed] = useState(false);
   const id = uuid();
   if (hours !== undefined) numHours = hours;
-
-  let style = {};
-  if (end) {
-    style = {border: '0'}
-  }
 
   let dividers = [];
   for (let i = 0; i < numHours; i++) {
@@ -189,7 +183,7 @@ export const SchedulingColumn: FC<Props> = ({blocks, end, filter, day, hours}) =
   }
 
   return (
-    <div className="vstack grow-h day column" style={style} id={id} onClick={select}>
+    <div className="vstack grow-h day column" id={id} onClick={select}>
       { (detailed) ? 
         <div className="day-label hstack" style={{padding: 0}}>
           <div className="left element detailed" style={{padding: '5px'}}>
@@ -206,7 +200,7 @@ export const SchedulingColumn: FC<Props> = ({blocks, end, filter, day, hours}) =
           </div>
         </div> 
       }
-      <div className="vstack day" style={style} >
+      <div className="vstack day" >
         { dividers }
         { generateBlocks(blocks, filter) }
       </div>

--- a/src/Components/Scheduling/SchedulingRender.tsx
+++ b/src/Components/Scheduling/SchedulingRender.tsx
@@ -13,7 +13,6 @@ interface Props {
 }
 
 export const SchedulingRender: FC<Props> = ({filter}) => {
-  console.log(start);
   return (
     <div className="render-container">
       < SchedulingTimes hours={hours} start={start}/>

--- a/src/Components/Scheduling/SchedulingRender.tsx
+++ b/src/Components/Scheduling/SchedulingRender.tsx
@@ -22,7 +22,7 @@ export const SchedulingRender: FC<Props> = ({filter}) => {
         < SchedulingColumn hours={hours} day={'Tuesday'} blocks={BlockFormer.samples.TH_shcedule} filter={filter} />
         < SchedulingColumn hours={hours} day={'Wednesday'} blocks={BlockFormer.samples.W_schedule} filter={filter} />
         < SchedulingColumn hours={hours} day={'Thursday'} blocks={BlockFormer.samples.TH_shcedule} filter={filter} />
-        < SchedulingColumn hours={hours} day={'Friday'} blocks={BlockFormer.samples.F_schedule} filter={filter} end={true} />
+        < SchedulingColumn hours={hours} day={'Friday'} blocks={BlockFormer.samples.F_schedule} filter={filter} />
       </div>
     </div>
   )

--- a/src/Components/common.scss
+++ b/src/Components/common.scss
@@ -274,9 +274,15 @@ $day_divider_size : 1.5px;
 		transition: all .2s ease-in-out;
 
 		.block-indicator {
-			flex: 1 1 auto;
-			height: 100%;
+			// flex: 1 1 auto;
+			// height: 100%;
 			text-align: center;
+			margin-top: 5px;
+
+			display: flex;
+			align-items: center;
+			flex-wrap: wrap;
+			justify-content: center;
 		}
 
 		.block-text {
@@ -377,7 +383,7 @@ $day_divider_size : 1.5px;
 	width: min(50%, 0.8em);
 	aspect-ratio: 1 / 1;
 	padding: 0;
-	margin: 10px 0 0 0;
+	margin: 0 1px 2px 1px;
 	background-color: $accent;
 	border-radius: 50%;
 	border: 0.15em solid $render_background;

--- a/src/Components/common.scss
+++ b/src/Components/common.scss
@@ -147,7 +147,6 @@ $google_bg: white;
 	padding-right: 10px;
 }
 
-
 .top-border {
 	border-top: 2px solid;
 }
@@ -193,7 +192,30 @@ $day_divider_size : 1.5px;
 	.day-label {
 		text-align: center;
 		color: $render_divider;
-		margin: 5px 0px;
+		padding: 5px 0px;
+		position: relative;
+
+		.element {
+			font-weight: bold;
+			transition: all .2s ease-in-out;
+		}
+
+		.left.detailed {
+			position: absolute;
+		}
+
+		.center.detailed {
+			color: red;
+			border-radius: 5px;
+			border: 1px solid red;
+			z-index: 3;
+		}
+
+		.center.detailed:hover {
+			background-color: red;
+			color: $render_background;
+			opacity: 0.4;
+		}
 	}
 	
 	.render-times {
@@ -214,6 +236,7 @@ $day_divider_size : 1.5px;
 	.render-content {
 		flex: 1 1 auto;
 		display: flex;
+		position: relative;
 
 		border: 2px solid black;
 		
@@ -223,6 +246,24 @@ $day_divider_size : 1.5px;
 		.day {
 			background-color: $render_background;
 			border-right: $day_divider_size solid $render_divider;
+		}
+
+		.day.detailed {
+			position: absolute;
+			height: 100%;
+			width: calc(100% - 10px);
+			z-index: 2;
+			margin-left: 5px;
+			border-radius: 5px;
+			box-shadow: 0 0 10px 0;
+		}
+
+		.day.undetailed {
+			filter: brightness(50%);
+		}
+
+		.day.undetailed {
+			filter: brightness(50%);
 		}
 	}	
 
@@ -299,8 +340,8 @@ $day_divider_size : 1.5px;
 	.block.selected {
 		position: absolute;
 		height: 100%;
-		width: 90%;
-		margin-left: 5%;
+		width: calc(100% - 14px);
+		margin-left: 7px;
 		z-index: 2;
 		
 		box-shadow: 0 0 10px 0;
@@ -316,11 +357,15 @@ $day_divider_size : 1.5px;
 }
 
 .grow-h {
+	transition: all .2s cubic-bezier(0.79, 1.38, 0.77, 1.39);
+}
+
+.grow-h:not(.undetailed, .detailed) {
 	transition: all .2s ease-in-out;
 }
 
-.grow-h:hover {
-	z-index: 2;
+.grow-h:hover:not(.undetailed, .detailed) {
+	z-index: 3;
 	border-radius: 5px;
 	// border: $day_divider_size solid $render_divider;
 	box-shadow: 0 0 10px 0;
@@ -403,7 +448,6 @@ $day_divider_size : 1.5px;
 }
 
 .hat {
-	// height: 0;
 	flex: 0 1 0;
 	width: calc(100% - 2px);
 	overflow: hidden;

--- a/src/Components/common.scss
+++ b/src/Components/common.scss
@@ -447,30 +447,65 @@ $day_divider_size : 1.5px;
 	transition: all .2s ease-in-out;
 }
 
+
 .hat {
-	flex: 0 1 0;
-	width: calc(100% - 2px);
-	overflow: hidden;
+	flex: 1 1 auto;
 	padding-left: 2px;
+	display: none;
+	text-overflow: ellipsis;
+
+	transition: all 0.2s ease-in-out;
+}
+
+
+.hat.selected, .hat.emphasized, .column.detailed .hat {
+	flex: 1 1 0;
+	display: inline-block;
+	overflow: hidden;
+	white-space: nowrap;
+}
+
+.column.detailed .hat {
+	border-left: 1px solid $light;
+	border-right: 1px solid $light;
+}
+
+.column.detailed .hat:first-child {
+	border-left: none;
+}
+
+.column.detailed .hat:last-child {
+	border-right: none;
+}
+
+.column.detailed .hat:hover, .column.detailed .hat.emphasized {
+	flex: 10000 0 auto;
+}
+
+.hat-container {
+	flex: 0 1 0;
+	width: 100%;
+	overflow: hidden;
 	font-size: 0.9em;
+
+	display: flex;
 
 	transition: all .2s ease-in-out;
 }
 
-.hat.selected {
-	height: 0.2em;
+.hat-container.selected {
+	flex: 0 0 0.2em;
 	border-radius: 3px 3px 0 0;
 	border-bottom: 2px solid black;
 }
 
-.hat.emphasized {
+.hat-container.emphasized, .column.detailed .hat-container {
 	flex: 0 0 1.2em;
-	// height: 1.2em;
 	border-radius: 3px 3px 0 0;
 	border-bottom: 2px solid white;
 }
 
-.hat.selected {
+.hat-container.selected {
 	border-bottom: 2px solid black;
 }
 

--- a/src/Components/common.scss
+++ b/src/Components/common.scss
@@ -283,6 +283,11 @@ $day_divider_size : 1.5px;
 			border-color: color.adjust($render_divider, $alpha: -0.6) $render_divider;
 		}
 	}
+
+	.absolute {
+		position: absolute;
+		height: 100%;
+	}
 }
 
 .render-container:last-child {
@@ -341,6 +346,12 @@ $day_divider_size : 1.5px;
 		}
 	}
 
+	.block.spacer {
+		height: 0;
+		visibility: hidden;
+		margin-right: 0;
+	}
+
 	.block.selected {
 		position: absolute;
 		height: 100%;
@@ -353,6 +364,11 @@ $day_divider_size : 1.5px;
 
 	.block.deselected {
 		filter: brightness(50%);
+	}
+
+	.block.invisible {
+		visibility: hidden;
+		max-height: 0;
 	}
 }
 

--- a/src/Components/common.scss
+++ b/src/Components/common.scss
@@ -285,6 +285,10 @@ $day_divider_size : 1.5px;
 	}
 }
 
+.render-container:last-child {
+	border: 0;
+}
+
 .block-container {
 	position: absolute;
 	width: 100%;
@@ -443,6 +447,9 @@ $day_divider_size : 1.5px;
 	border-radius: 50%;
 	border: 0.15em solid $render_background;
 	display: inline-block;
+
+	margin: 0;
+	width: 0.7em;
 
 	transition: all .2s ease-in-out;
 }

--- a/src/Components/common.scss
+++ b/src/Components/common.scss
@@ -271,7 +271,7 @@ $day_divider_size : 1.5px;
 	
 		border-radius: 3px;
 
-		transition: all .2s ease-in-out;
+		transition: all 0.2s ease-in-out;
 
 		.block-indicator {
 			flex: 1 1 auto;
@@ -286,8 +286,14 @@ $day_divider_size : 1.5px;
 		}
 	}
 
+	.block.selected {
+		flex: 1000 0 auto;
+	}
+
 	.block.deselected {
-		filter: brightness(50%); // To overwrite element.style given by javascript
+		width: 6px;
+		// flex: 1 1 6px;
+		filter: brightness(50%);
 	}
 }
 
@@ -357,7 +363,6 @@ $day_divider_size : 1.5px;
 	
 	.vstack {
 		margin-right: 10px;
-		// background: rgb(255, 255, 255);
 		padding: 0px 10px;
 		border-radius: 2px;
 	}
@@ -374,10 +379,7 @@ $day_divider_size : 1.5px;
 }
 
 .dot {
-	width: min(50%, 0.8em);
 	aspect-ratio: 1 / 1;
-	padding: 0;
-	margin: 10px 0 0 0;
 	background-color: $accent;
 	border-radius: 50%;
 	border: 0.15em solid $render_background;
@@ -386,19 +388,23 @@ $day_divider_size : 1.5px;
 	transition: all .2s ease-in-out;
 }
 
-.dot.inactive {
-	background-color: transparent;
-	border: 0.15em solid black;
+.hat {
+	height: 0;
+	width: 100%;
+
+	transition: all .2s ease-in-out;
 }
 
-.dot.deemphasized {
-	border: 0.15em solid black;
-	transform: scale(0.3);
+.hat.emphasized {
+	height: 1em;
+	border-radius: 3px 3px 0 0;
+	border-bottom: 2px solid white;
 }
 
-.dot.deselected {
-	border: 0.15em solid black;
-	transform: scale(0.3);
+.hat.selected {
+	height: 1.3em;
+	border-radius: 3px 3px 0 0;
+	border-bottom: 2px solid black;
 }
 
 .dot.emphasized {
@@ -407,6 +413,15 @@ $day_divider_size : 1.5px;
 
 .dot.selected {
 	transform: scale(1.3);
+}
+
+.dot.deemphasized {
+	transform: scale(0.5);
+}
+
+.dot.deselected {
+	border-color: black;
+	transform: scale(0.3);
 }
 
 .dot.emphasized:hover {

--- a/src/Components/common.scss
+++ b/src/Components/common.scss
@@ -395,6 +395,12 @@ $day_divider_size : 1.5px;
 	transition: all .2s ease-in-out;
 }
 
+.hat.selected {
+	height: 0.2em;
+	border-radius: 3px 3px 0 0;
+	border-bottom: 2px solid black;
+}
+
 .hat.emphasized {
 	height: 1em;
 	border-radius: 3px 3px 0 0;
@@ -402,10 +408,9 @@ $day_divider_size : 1.5px;
 }
 
 .hat.selected {
-	height: 1.3em;
-	border-radius: 3px 3px 0 0;
 	border-bottom: 2px solid black;
 }
+
 
 .dot.emphasized {
 	transform: scale(1.3);

--- a/src/Components/common.scss
+++ b/src/Components/common.scss
@@ -272,6 +272,7 @@ $day_divider_size : 1.5px;
 		border-radius: 3px;
 
 		transition: all 0.2s ease-in-out;
+		// transition: position 0.01s ease-in-out 1s;
 
 		.block-indicator {
 			// flex: 1 1 auto;
@@ -293,12 +294,16 @@ $day_divider_size : 1.5px;
 	}
 
 	.block.selected {
-		flex: 1000 0 auto;
+		position: absolute;
+		height: 100%;
+		width: 90%;
+		margin-left: 5%;
+		z-index: 2;
+		
+		box-shadow: 0 0 10px 0;
 	}
 
 	.block.deselected {
-		width: 6px;
-		// flex: 1 1 6px;
 		filter: brightness(50%);
 	}
 }

--- a/src/Components/common.scss
+++ b/src/Components/common.scss
@@ -423,6 +423,11 @@ $day_divider_size : 1.5px;
 
 		transition: all 0.1s ease-in-out;
 	}
+
+	button:hover {
+		background-color: darken($google_bg, 10%);
+		cursor: pointer;
+	}
 	
 	.vstack {
 		margin-right: 10px;
@@ -434,11 +439,6 @@ $day_divider_size : 1.5px;
 		padding-right: 10px;
 		font-weight: 500;
 	}	
-}
-
-.google button:hover {
-	background-color: darken($google_bg, 10%);
-	cursor: pointer;
 }
 
 .dot {
@@ -454,7 +454,6 @@ $day_divider_size : 1.5px;
 	transition: all .2s ease-in-out;
 }
 
-
 .hat {
 	flex: 1 1 auto;
 	padding-left: 2px;
@@ -463,7 +462,6 @@ $day_divider_size : 1.5px;
 
 	transition: all 0.2s ease-in-out;
 }
-
 
 .hat.selected, .hat.emphasized, .column.detailed .hat {
 	flex: 1 1 0;
@@ -516,12 +514,12 @@ $day_divider_size : 1.5px;
 	border-bottom: 2px solid black;
 }
 
-.dot.emphasized {
+.dot.emphasized, .dot.selected {
 	transform: scale(1.3);
 }
 
-.dot.selected {
-	transform: scale(1.3);
+.dot.emphasized:hover, .dot.selected:hover {
+	cursor: pointer;
 }
 
 .dot.deemphasized {
@@ -531,14 +529,6 @@ $day_divider_size : 1.5px;
 .dot.deselected {
 	border-color: black;
 	transform: scale(0.3);
-}
-
-.dot.emphasized:hover {
-	cursor: pointer;
-}
-
-.dot.selected:hover {
-	cursor: pointer;
 }
 
 img {

--- a/src/Components/common.scss
+++ b/src/Components/common.scss
@@ -320,6 +320,7 @@ $day_divider_size : 1.5px;
 		min-width: 0;
 	
 		border-radius: 3px;
+		z-index: 1;
 
 		transition: all 0.2s ease-in-out;
 		// transition: position 0.01s ease-in-out 1s;

--- a/src/Components/common.scss
+++ b/src/Components/common.scss
@@ -290,6 +290,9 @@ $day_divider_size : 1.5px;
 			color: $light;
 			overflow: hidden;
 			padding-bottom: 5px;
+			flex: 1 1 auto;
+			display: flex;
+			align-items: flex-end;
 		}
 	}
 
@@ -400,8 +403,12 @@ $day_divider_size : 1.5px;
 }
 
 .hat {
-	height: 0;
-	width: 100%;
+	// height: 0;
+	flex: 0 1 0;
+	width: calc(100% - 2px);
+	overflow: hidden;
+	padding-left: 2px;
+	font-size: 0.9em;
 
 	transition: all .2s ease-in-out;
 }
@@ -413,7 +420,8 @@ $day_divider_size : 1.5px;
 }
 
 .hat.emphasized {
-	height: 1em;
+	flex: 0 0 1.2em;
+	// height: 1.2em;
 	border-radius: 3px 3px 0 0;
 	border-bottom: 2px solid white;
 }
@@ -421,7 +429,6 @@ $day_divider_size : 1.5px;
 .hat.selected {
 	border-bottom: 2px solid black;
 }
-
 
 .dot.emphasized {
 	transform: scale(1.3);

--- a/src/Tests/Unit/EmployeeList/EmployeeRow.test.tsx
+++ b/src/Tests/Unit/EmployeeList/EmployeeRow.test.tsx
@@ -7,7 +7,7 @@ configure({testIdAttribute: 't-id'});
 
 describe('EmployeeRow', () => {
     let subject: RenderResult;
-    beforeEach(() => subject = render(< EmployeeRow element={"John Doe"} />))
+    beforeEach(() => subject = render(< EmployeeRow linkID={1} element={"John Doe"} />))
     
     it('has a checkbox', () => {
         const element = screen.getByRole('checkbox');

--- a/src/Tests/Unit/Scheduling/SchedulingBlock.test.tsx
+++ b/src/Tests/Unit/Scheduling/SchedulingBlock.test.tsx
@@ -11,7 +11,7 @@ describe('SchedulingBlock', () => {
             start:  new Date(0), 
             end: new Date(1000*60*50) // 50 minutes long
         }
-    }/>));
+    } linkIDs={[]}/>));
 
     it('displays the course', () => {
         const element = screen.getByText(/121/);

--- a/src/Tests/Unit/Scheduling/SchedulingColumn.test.tsx
+++ b/src/Tests/Unit/Scheduling/SchedulingColumn.test.tsx
@@ -29,7 +29,7 @@ describe('SchedulingColumn (SchedulingBlock Dependent)', () => {
             expect(element).toBeInTheDocument();
         });
         
-        it('displays one short element', () => {
+        it('displays one long element', () => {
             render(< SchedulingColumn day={'Mon'} filter={{121: true}} blocks={[
                 {course: 121, section: 101, start: BlockFormer.starts.MW_A, end: BlockFormer.setTimes.MW_A_extralong},
             ]}/>)

--- a/src/uuid.tsx
+++ b/src/uuid.tsx
@@ -1,8 +1,3 @@
-/**
-A function that returns a universally unique identifier (uuid).  
-example: 1b83fd69-abe7-468c-bea1-306a8aa1c81d
-@returns `string` : 32 character uuid (see example)
-*/
 function uuid() {
     const hashTable = [ 'a', 'b', 'c', 'd', 'e', 'f', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
     let uuid = []


### PR DESCRIPTION
**If possible, as part of the review, please run the application and see how these features feel as someone who is less familiar with them.** I'd like these features to be pretty final before getting merged into frontend.

Made up of 2 major enhancements and one minor fix

1. Implemented the MultiDot system in the form of Hats. Each scheduling block is given a multitude of hats, each of which is linked to the employee scheduled to that block. Hovering the dot tied to that employee reveals the hats. Clicking a dot will expand the block to cover the entire width of the day, and clicking again anywhere on the screen will return the view to normal.
2. The detail view can be accessed by clicking anywhere on a particular day in the render window. The selected day will fill the entire render window and the hats will reveal themselves permanently alongside the name of the employee each is related to. Hovering each hat will have it fill the block and attempt to display the entire name, and clicking the dot related to an employee will have a similar selection effect as 1, except that all hats will remain displayed if the mouse is not hovering them. The detail view can be exited by clicking `Exit` in red towards the top of the render window.
3. The minor fix is related to the renders in which multiple block heights are rendered. Before, the taller blocks were given a fixed size unrelated to the view size. Now, they are the same width as the smallest block occurring at the same time and are dynamically resizable like all other blocks.

I would like to revisit the math that calculates the color of each dot from the given ID, for larger numbers of employees I feel there isn't enough distance between some of the colors but for now, I think it's a good start, and can be revisited later.

There was a fair bit of refactoring done in regards to the SCSS file, so please be careful during merges in other branches to be sure the CSS doesn't break!