### PR TITLE
Fix scheduling order

### DIFF
--- a/lambda/postSchedulePeerTeachers/Scheduler/src/main/java/db/Person.java
+++ b/lambda/postSchedulePeerTeachers/Scheduler/src/main/java/db/Person.java
@@ -220,7 +220,7 @@ public class Person implements Comparable<Person> {
 
     @Override
     public int compareTo(Person other) {
-        return availabilityScore < other.availabilityScore ? 1 : other.availabilityScore < availabilityScore ? -1 : 0;
+        return availabilityScore < other.availabilityScore ? -1 : other.availabilityScore < availabilityScore ? 1 : 0;
     }
 
     static boolean timeContains(Time outer_start, Time outer_end, Time inner_start, Time inner_end) {


### PR DESCRIPTION
The scheduler schedules by availability score, but it was running in the wrong order. I noticed this when I was scheduled to exactly the courses I requested as "preferred" despite having the highest availability score in the database. As such, I did some testing and determined the issue was in the implementation of `Person.compareTo`. This PR addresses the problem.