### PR TITLE
Update getUserViability lambda to use new Viability view

### DIFF
--- a/lambda/getUserViableCourses/index.js
+++ b/lambda/getUserViableCourses/index.js
@@ -3,7 +3,16 @@ const helper_functions = require("./helper_functions");
 exports.handler = async (event) => {
     let userId = event?.pathParameters?.userId;
     
-    let dbQuery = `SELECT * FROM "ViableCourses"($1)`;
+    let accessHeader = null;
+    
+    if (event.headers.origin == 'https://www.csce-scheduler.com') {
+        accessHeader = 'https://www.csce-scheduler.com';
+    }
+    else if (event.headers.origin == 'http://localhost:3000') {
+        accessHeader = 'http://localhost:3000';
+    }
+    
+    let dbQuery = `SELECT * FROM "Viability" WHERE person_id = $1`;
     let params = [userId];
     
     let dbRows = await helper_functions.queryDB(dbQuery, params);
@@ -15,7 +24,7 @@ exports.handler = async (event) => {
     const response = {
         "isBase64Encoded": false,
         "statusCode": 200,
-        "headers": { "Content-Type": "application/json", "Access-Control-Allow-Origin": "http://localhost:3000" },
+        "headers": { "Content-Type": "application/json", "Access-Control-Allow-Origin": accessHeader },
         "body": JSON.stringify(responseBody)
     };
 


### PR DESCRIPTION
I added the database view `Viability` and this PR changes the `getUserViableCourses` lambda to use the new view in an attempt to begin to deprecate the old `ViableCourses` funciton.